### PR TITLE
activar protección de merges a main (solo desde develop)

### DIFF
--- a/.github/workflows/only-develop-into-main.yml
+++ b/.github/workflows/only-develop-into-main.yml
@@ -1,0 +1,24 @@
+name: protect-main (only allow PRs from develop)
+
+# Este workflow se ejecutará automáticamente cuando alguien abra un Pull Request hacia 'main'
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  enforce-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR source branch
+        run: |
+          # Muestro por consola la rama destino y la rama origen del Pull Request
+          echo "Base branch  : ${{ github.base_ref }}"
+          echo "Source branch: ${{ github.head_ref }}"
+
+          # Regla de seguridad: solo se permiten PRs a 'main' si vienen desde 'develop'
+          if [[ "${{ github.head_ref }}" != "develop" ]]; then
+            echo "::error::Solo se permiten PRs a 'main' desde 'develop'."
+            echo "::error::Rama origen actual: '${{ github.head_ref }}'"
+            exit 1
+          fi


### PR DESCRIPTION
Este Pull Request introduce un workflow de GitHub Actions que bloquea los merges a la rama main
si no provienen directamente desde develop. 

El objetivo de esto es mantener un flujo de trabajo seguro tipo GitFlow:
(feature/*) → develop → main